### PR TITLE
Don't report skipped tests as failure, and add message with the reason why the test was skipped

### DIFF
--- a/lib/minitest/junit.rb
+++ b/lib/minitest/junit.rb
@@ -33,10 +33,13 @@ module Minitest
         xml = Builder::XmlMarkup.new
         xml.testcase classname: format_class(result), name: format_name(result),
                      time: result.time, assertions: result.assertions do |t|
-          t.skipped if result.skipped?
-          result.failures.each do |failure|
-            type = classify failure
-            xml.tag! type, format_backtrace(failure), message: result
+          if result.skipped?
+            t.skipped message: result
+          else
+            result.failures.each do |failure|
+              type = classify failure
+              xml.tag! type, format_backtrace(failure), message: result
+            end
           end
         end
         xml.target!

--- a/minitest-junit.gemspec
+++ b/minitest-junit.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'minitest', '~> 5.0'
   spec.add_dependency 'builder', '~> 3.2'
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.3.2'
   spec.add_development_dependency 'rubocop', '~> 0.24.1'
 end

--- a/test/testcase_formatter_test.rb
+++ b/test/testcase_formatter_test.rb
@@ -20,7 +20,7 @@ class TestCaseFormatter < Minitest::Test
 
     reporter.report
 
-    assert_match(/<skipped message=".+"\/>.*/, reporter.output)
+    assert_match(/<skipped message="[^<>]+"\/><\/testcase>\n<\/testsuite>\n/, reporter.output)
   end
 
   def test_failing_tests_creates_failure_tag

--- a/test/testcase_formatter_test.rb
+++ b/test/testcase_formatter_test.rb
@@ -20,7 +20,7 @@ class TestCaseFormatter < Minitest::Test
 
     reporter.report
 
-    assert_match(/<skipped\/>/, reporter.output)
+    assert_match(/<skipped message=".+"\/>.*/, reporter.output)
   end
 
   def test_failing_tests_creates_failure_tag


### PR DESCRIPTION
Hello Allan, 

While using minitest-junit to generate junit-style reports to upload into Gitlab CI, we realized that tests that were skipped by minitest were reported as failures by gitlab CI : indeed the xml generated for those test contained a <failure> element, as well as a <skipped/> element. Il looked into the documentation of the Junit XML format at https://llg.cubic.org/docs/junit/ and I think those two elements should not be present within a <testcase> element.

Do you agree with this? if so, do you think it would be possible to include this fix in a future version of minitest-junit ? 

Thank you in advance,

Garz