### PR TITLE
1.1.0 Output properly formed JUnit schema, including top-level attributes

### DIFF
--- a/lib/minitest/junit.rb
+++ b/lib/minitest/junit.rb
@@ -36,16 +36,18 @@ module Minitest
                       skipped: @results.count { |result| result.skipped? },
                       failures: @results.count { |result| !result.error? && result.failure },
                       errors: @results.count { |result| result.error? },
-                      time: format_time(@results.inject(0) { |accum, result| accum += result.time }) ) do
+                      time: format_time(@results.inject(0) { |a, e| a += e.time })) do
                         @results.each { |result| format(result, xml) }
                       end
         @io.puts xml.target!
       end
 
-      def format(result, parent=nil)
+      def format(result, parent = nil)
         xml = Builder::XmlMarkup.new(:target => parent, :indent => 2)
-        xml.testcase classname: format_class(result), name: format_name(result),
-                     time: format_time(result.time), assertions: result.assertions do |t|
+        xml.testcase classname: format_class(result),
+                     name: format_name(result),
+                     time: format_time(result.time),
+                     assertions: result.assertions do |t|
           if result.skipped?
             t.skipped message: result
           else
@@ -85,9 +87,8 @@ module Minitest
       end
 
       def format_time(time)
-        '%.6f' % time
+        Kernel::format('%.6f', time)
       end
-
     end
   end
 end

--- a/lib/minitest/junit.rb
+++ b/lib/minitest/junit.rb
@@ -13,6 +13,8 @@ module Minitest
         @io = io
         @results = []
         @options = options
+        @options[:timestamp] = options.fetch(:timestamp, Time.now.iso8601)
+        @options[:hostname] = options.fetch(:hostname, Socket.gethostname)
       end
 
       def passed?
@@ -28,8 +30,8 @@ module Minitest
       def report
         xml = Builder::XmlMarkup.new(:indent => 2)
         xml.testsuite(name: 'minitest',
-                      timestamp: Time.now.iso8601,
-                      hostname: Socket.gethostname,
+                      timestamp: @options[:timestamp],
+                      hostname: @options[:hostname],
                       tests: @results.count,
                       skipped: @results.count { |result| result.skipped? },
                       failures: @results.count { |result| !result.error? && result.failure },

--- a/lib/minitest/junit/version.rb
+++ b/lib/minitest/junit/version.rb
@@ -1,6 +1,6 @@
 module Minitest
   # :nodoc:
   module Junit
-    VERSION = '0.3.0'
+    VERSION = '0.4.0'
   end
 end

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -6,64 +6,72 @@ require 'time'
 require 'minitest/junit'
 
 class ReporterTest < Minitest::Test
-  class MockResult
-    attr_accessor :name, :failures, :time
-    def initialize(name, error=false, skipped=false, failures=[], time=60)
-      @name = name
-      @skipped = skipped
-      @error = error
-      @failures = failures
-      @time = time
-    end
-
-    def error?
-      @error
-    end
-
-    def failure
-      @failures.first
-    end
-
-    def skipped?
-      @skipped
-    end
-  end
-
   def test_no_tests_generates_an_empty_suite
     reporter = create_reporter
 
     reporter.report
 
-    assert_match /^<testsuite name="minitest" timestamp="[^"]+" hostname="[^"]+" tests="0" skipped="0" failures="0" errors="0" time="0.000000">\n<\/testsuite>\n$/, reporter.output
+    assert_match(/^<testsuite name="minitest" timestamp="[^"]+" hostname="[^"]+" tests="0" skipped="0" failures="0" errors="0" time="0.000000">\n<\/testsuite>\n$/, reporter.output)
   end
 
-  def test_formats_each_result_with_a_formatter
+  def test_formats_each_successful_result_with_a_formatter
     reporter = create_reporter
-    results = rand(100).times.map do |i|
-      result = MockResult.new "test_name#{i}"
+
+    results = do_formatting_test(reporter, count: rand(100), cause_failures: 0)
+
+    results.each do |result|
+      assert_match("<testcase classname=\"FakeTestName\" name=\"#{result.name}\"", reporter.output)
+    end
+  end
+
+  def test_formats_each_failed_result_with_a_formatter
+    reporter = create_reporter
+
+    results = do_formatting_test(reporter, count: rand(100), cause_failures: 1)
+
+    results.each do |result|
+      assert_match("<testcase classname=\"FakeTestName\" name=\"#{result.name}\"", reporter.output)
+      assert_match(/<failure/, reporter.output)
+    end
+  end
+
+  private
+
+  def do_formatting_test(reporter, count: 1, cause_failures: 0)
+    results = count.times.map do |i|
+      result = create_test_result(methodname: "test_name#{i}", failures: cause_failures)
       reporter.record result
       result
     end
 
     reporter.report
 
-    results.each do |result|
-      assert_match "<testcase name=\"#{result.name}\"\/>", reporter.output
-    end
+    results
   end
 
-  private
+  def create_test_result(name: FakeTestName, methodname: 'test_method_name', successes: 1, failures: 0)
+    test = Class.new Minitest::Test do
+      define_method 'class' do
+        name
+      end
+    end.new methodname
+    test.time = rand(100)
+    test.assertions = successes + failures
+    test.failures = failures.times.map do |i|
+      Class.new Minitest::Assertion do
+        define_method 'backtrace' do
+          ["Model failure \##{i}", 'This is a test backtrace']
+        end
+      end.new
+    end
+    Minitest::Result.from test
+  end
 
-  def create_reporter
-    io = StringIO.new
-    reporter = Minitest::Junit::Reporter.new io, {}
+  def create_reporter(options = {})
+    io = StringIO.new ''
+    reporter = Minitest::Junit::Reporter.new io, options
     def reporter.output
       @io.string
-    end
-    def reporter.format(result, parent=nil)
-      xml = Builder::XmlMarkup.new(:target=>parent)
-      xml.testcase name: result.name
-      result
     end
     reporter.start
     reporter

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -1,30 +1,55 @@
 require 'minitest/autorun'
+require 'builder'
 require 'stringio'
 require 'time'
 
 require 'minitest/junit'
 
 class ReporterTest < Minitest::Test
+  class MockResult
+    attr_accessor :name, :failures, :time
+    def initialize(name, error=false, skipped=false, failures=[], time=60)
+      @name = name
+      @skipped = skipped
+      @error = error
+      @failures = failures
+      @time = time
+    end
+
+    def error?
+      @error
+    end
+
+    def failure
+      @failures.first
+    end
+
+    def skipped?
+      @skipped
+    end
+  end
+
   def test_no_tests_generates_an_empty_suite
     reporter = create_reporter
 
     reporter.report
 
-    assert_equal "<testsuite>\n</testsuite>\n", reporter.output
+    assert_match /^<testsuite name="minitest" timestamp="[^"]+" hostname="[^"]+" tests="0" skipped="0" failures="0" errors="0" time="0.000000">\n<\/testsuite>\n$/, reporter.output
   end
 
   def test_formats_each_result_with_a_formatter
     reporter = create_reporter
     results = rand(100).times.map do |i|
-      result = "test_name#{i}"
+      result = MockResult.new "test_name#{i}"
       reporter.record result
       result
     end
 
     reporter.report
 
-    expected = "<testsuite>\n#{results.join "\n"}\n</testsuite>\n"
-    assert_equal expected, reporter.output
+    results.each do |result|
+      assert_match "<testcase name=\"#{result.name}\"\/>", reporter.output
+    end
   end
 
   private
@@ -35,7 +60,9 @@ class ReporterTest < Minitest::Test
     def reporter.output
       @io.string
     end
-    def reporter.format(result)
+    def reporter.format(result, parent=nil)
+      xml = Builder::XmlMarkup.new(:target=>parent)
+      xml.testcase name: result.name
       result
     end
     reporter.start

--- a/test/testcase_formatter_test.rb
+++ b/test/testcase_formatter_test.rb
@@ -9,7 +9,7 @@ class TestCaseFormatter < Minitest::Test
     test = create_test_result
     reporter = create_reporter
 
-    assert_match test.name, reporter.format(test)
+    assert_match test.name, reporter.format(test).target!
   end
 
   def test_skipped_tests_generates_skipped_tag
@@ -20,7 +20,7 @@ class TestCaseFormatter < Minitest::Test
 
     reporter.report
 
-    assert_match(/<skipped message="[^<>]+"\/><\/testcase>\n<\/testsuite>\n/, reporter.output)
+    assert_match(/<skipped message="[^<>]+"\/>\n<\/testcase>\n<\/testsuite>\n/, reporter.output)
   end
 
   def test_failing_tests_creates_failure_tag


### PR DESCRIPTION
This change improves the completeness of the JUnit schema output by this plugin such that it fully adheres to https://github.com/junit-team/junit5/blob/main/platform-tests/src/test/resources/jenkins-junit.xsd as well as is able to be interpreted by the [GitLab](https://gitlab.com/rluna-gitlab/gitlab-ce) JUnit parser.

Version number is also incremented to 0.4.0.