### PR TITLE
Adds backtrace filter and removes absolute paths

### DIFF
--- a/lib/minitest/junit.rb
+++ b/lib/minitest/junit.rb
@@ -53,7 +53,7 @@ module Minitest
           else
             result.failures.each do |failure|
               type = classify failure
-              xml.tag! type, format_backtrace(failure), message: result
+              xml.tag! type, format_backtrace(failure), message: failure_message(result)
             end
           end
         end
@@ -70,8 +70,18 @@ module Minitest
         end
       end
 
+      def working_directory
+        @working_directory ||= Dir.getwd
+      end
+
+      def failure_message(result)
+        "#{result.klass}##{result.name}: #{result.failure.to_s}"
+      end
+
       def format_backtrace(failure)
-        failure.backtrace.join("\n")
+        Minitest.filter_backtrace(failure.backtrace).map do |line|
+          line.gsub(working_directory, '.')
+        end.join("\n")
       end
 
       def format_class(result)

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -60,7 +60,7 @@ class ReporterTest < Minitest::Test
     test.failures = failures.times.map do |i|
       Class.new Minitest::Assertion do
         define_method 'backtrace' do
-          ["Model failure \##{i}", 'This is a test backtrace']
+          ["Model failure \##{i}", 'This is a test backtrace', "#{__FILE__}:#{__LINE__}"]
         end
       end.new
     end


### PR DESCRIPTION
- Uses Minitest backtrace filter to avoid paths to the
  internal Minitest methods.

- Removes absolute paths from backtraces:
  `/Users/username/project/test/test_helper.rb:5:in block in <top (required)>`
  is turned into
  `test/test_helper.rb:5:in block in <top (required)>`
