### PR TITLE
Feature: allow file and line attributes in junit report

### DIFF
--- a/lib/minitest/junit.rb
+++ b/lib/minitest/junit.rb
@@ -47,6 +47,8 @@ module Minitest
         xml.testcase classname: format_class(result),
                      name: format_name(result),
                      time: format_time(result.time),
+                     file: result.source_location.first,
+                     line: result.source_location.last,
                      assertions: result.assertions do |t|
           if result.skipped?
             t.skipped message: result

--- a/minitest-junit.gemspec
+++ b/minitest-junit.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'builder', '~> 3.2'
 
   spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'nokogiri'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 10.3.2'
   spec.add_development_dependency 'rubocop', '~> 0.24.1'
 end


### PR DESCRIPTION
This is particularly useful when debugging a failed test in a report. Without these attributes, we would have to rely on the backtrace, which doesn't accurately pinpoint the file and line of the original test.



