### PR TITLE
Reporter: Outputs XML with Ox

### DIFF
--- a/minitest-junit.gemspec
+++ b/minitest-junit.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'minitest', '~> 5.11'
-  spec.add_dependency 'builder', '~> 3.2'
+  spec.add_dependency 'ox', '~> 2', '>= 2.14.2'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'nokogiri'
   spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rake', '~> 10.3.2'
-  spec.add_development_dependency 'rubocop', '~> 0.24.1'
+  spec.add_development_dependency 'rake', '~> 13'
+  spec.add_development_dependency 'rubocop', '~> 1'
 end

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -1,10 +1,11 @@
 require 'minitest/autorun'
-require 'builder'
 require 'stringio'
 require 'time'
 require 'nokogiri'
 
 require 'minitest/junit'
+
+class FakeTestName; end
 
 class ReporterTest < Minitest::Test
   def test_no_tests_generates_an_empty_suite
@@ -12,7 +13,10 @@ class ReporterTest < Minitest::Test
 
     reporter.report
 
-    assert_match(/^<testsuite name="minitest" timestamp="[^"]+" hostname="[^"]+" tests="0" skipped="0" failures="0" errors="0" time="0.000000">\n<\/testsuite>\n$/, reporter.output)
+    assert_match(
+      %r{<?xml version="1.0" encoding="UTF-8"\?>\n<testsuite name="minitest" timestamp="[^"]+" hostname="[^"]+" tests="0" skipped="0" failures="0" errors="0" time="0.000000"\/>},
+      reporter.output
+    )
   end
 
   def test_formats_each_successful_result_with_a_formatter

--- a/test/testcase_formatter_test.rb
+++ b/test/testcase_formatter_test.rb
@@ -17,7 +17,10 @@ class TestCaseFormatter < Minitest::Test
     test = create_test_result
     reporter = create_reporter
 
-    assert_match test.name, reporter.format(test).target!
+    assert_match(
+      test.name,
+      reporter.format(test).attributes['name']
+    )
   end
 
   def test_skipped_tests_generates_skipped_tag
@@ -28,7 +31,7 @@ class TestCaseFormatter < Minitest::Test
 
     reporter.report
 
-    assert_match(/<skipped message="[^<>]+"\/>\n<\/testcase>\n<\/testsuite>\n/, reporter.output)
+    assert_match(/<skipped message="[^<>]+"\><\/skipped>\n\s+<\/testcase>\n\s*<\/testsuite>\n/, reporter.output)
   end
 
   def test_failing_tests_creates_failure_tag


### PR DESCRIPTION
- Fixes part of #6
- Adds version tag to XML-document
- Updates gemspec versions to work with Ruby 3


<details>
<summary>Before</summary>

```xml
<testsuite name="minitest" timestamp="2024-02-11T15:14:22+01:00" hostname="Davids-MBP" tests="17" skipped="0" failures="0" errors="0" time="0.051671">
<testcase classname="ReporterTest" name="test_formats_each_failed_result_with_a_formatter" time="0.045122" file="/Users/davidwessman/programming/gems/minitest-junit/test/reporter_test.rb" line="28" assertions="1">
</testcase>
<testcase classname="ReporterTest" name="test_no_tests_generates_an_empty_suite" time="0.000221" file="/Users/davidwessman/programming/gems/minitest-junit/test/reporter_test.rb" line="10" assertions="2">
</testcase>
<testcase classname="ReporterTest" name="test_xml_nodes_has_file_and_line_attributes" time="0.000703" file="/Users/davidwessman/programming/gems/minitest-junit/test/reporter_test.rb" line="40" assertions="4">
</testcase>
<testcase classname="ReporterTest" name="test_formats_each_successful_result_with_a_formatter" time="0.003344" file="/Users/davidwessman/programming/gems/minitest-junit/test/reporter_test.rb" line="18" assertions="62">
</testcase>
<testcase classname="PluginTest" name="test_by_default_doesnt_include_the_repoter" time="0.000030" file="/Users/davidwessman/programming/gems/minitest-junit/test/junit_plugin_test.rb" line="25" assertions="1">
</testcase>
<testcase classname="PluginTest" name="test_output_is_dumped_to_reportxml_by_default" time="0.000077" file="/Users/davidwessman/programming/gems/minitest-junit/test/junit_plugin_test.rb" line="43" assertions="0">
</testcase>
<testcase classname="PluginTest" name="test_setting_the_commandline_activates_the_plugin" time="0.000164" file="/Users/davidwessman/programming/gems/minitest-junit/test/junit_plugin_test.rb" line="16" assertions="1">
</testcase>
<testcase classname="PluginTest" name="test_by_default_the_plugin_is_disabled" time="0.000115" file="/Users/davidwessman/programming/gems/minitest-junit/test/junit_plugin_test.rb" line="6" assertions="1">
</testcase>
<testcase classname="PluginTest" name="test_custom_filename_is_specified_by_a_flag" time="0.000120" file="/Users/davidwessman/programming/gems/minitest-junit/test/junit_plugin_test.rb" line="66" assertions="1">
</testcase>
<testcase classname="PluginTest" name="test_jenkins_sanitization_is_specified_by_a_flag" time="0.000103" file="/Users/davidwessman/programming/gems/minitest-junit/test/junit_plugin_test.rb" line="76" assertions="1">
</testcase>
<testcase classname="PluginTest" name="test_when_enabled_adds_the_plugin_to_the_list_of_reporters" time="0.000104" file="/Users/davidwessman/programming/gems/minitest-junit/test/junit_plugin_test.rb" line="34" assertions="1">
</testcase>
<testcase classname="PluginTest" name="test_output_is_dumped_to_specified_filename" time="0.000038" file="/Users/davidwessman/programming/gems/minitest-junit/test/junit_plugin_test.rb" line="54" assertions="0">
</testcase>
<testcase classname="TestCaseFormatter" name="test_all_tests_generate_testcase_tag" time="0.000180" file="/Users/davidwessman/programming/gems/minitest-junit/test/testcase_formatter_test.rb" line="16" assertions="2">
</testcase>
<testcase classname="TestCaseFormatter" name="test_skipped_tests_generates_skipped_tag" time="0.000390" file="/Users/davidwessman/programming/gems/minitest-junit/test/testcase_formatter_test.rb" line="23" assertions="2">
</testcase>
<testcase classname="TestCaseFormatter" name="test_jenkins_sanitizer_uses_modules_as_packages" time="0.000246" file="/Users/davidwessman/programming/gems/minitest-junit/test/testcase_formatter_test.rb" line="56" assertions="2">
</testcase>
<testcase classname="TestCaseFormatter" name="test_failing_tests_creates_failure_tag" time="0.000358" file="/Users/davidwessman/programming/gems/minitest-junit/test/testcase_formatter_test.rb" line="34" assertions="2">
</testcase>
<testcase classname="TestCaseFormatter" name="test_other_errors_generates_error_tag" time="0.000356" file="/Users/davidwessman/programming/gems/minitest-junit/test/testcase_formatter_test.rb" line="45" assertions="2">
</testcase>
</testsuite>
```

</details>

<details>
<summary>After</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="minitest" timestamp="2024-02-11T15:13:17+01:00" hostname="Davids-MBP" tests="17" skipped="0" failures="0" errors="0" time="0.017793">
  <testcase classname="TestCaseFormatter" name="test_all_tests_generate_testcase_tag" time="0.000153" file="./test/testcase_formatter_test.rb" line="16" assertions="2"/>
  <testcase classname="TestCaseFormatter" name="test_other_errors_generates_error_tag" time="0.000339" file="./test/testcase_formatter_test.rb" line="48" assertions="2"/>
  <testcase classname="TestCaseFormatter" name="test_jenkins_sanitizer_uses_modules_as_packages" time="0.000239" file="./test/testcase_formatter_test.rb" line="59" assertions="2"/>
  <testcase classname="TestCaseFormatter" name="test_failing_tests_creates_failure_tag" time="0.000257" file="./test/testcase_formatter_test.rb" line="37" assertions="2"/>
  <testcase classname="TestCaseFormatter" name="test_skipped_tests_generates_skipped_tag" time="0.000180" file="./test/testcase_formatter_test.rb" line="26" assertions="2"/>
  <testcase classname="PluginTest" name="test_when_enabled_adds_the_plugin_to_the_list_of_reporters" time="0.000059" file="./test/junit_plugin_test.rb" line="34" assertions="1"/>
  <testcase classname="PluginTest" name="test_setting_the_commandline_activates_the_plugin" time="0.000106" file="./test/junit_plugin_test.rb" line="16" assertions="1"/>
  <testcase classname="PluginTest" name="test_jenkins_sanitization_is_specified_by_a_flag" time="0.000074" file="./test/junit_plugin_test.rb" line="76" assertions="1"/>
  <testcase classname="PluginTest" name="test_custom_filename_is_specified_by_a_flag" time="0.000084" file="./test/junit_plugin_test.rb" line="66" assertions="1"/>
  <testcase classname="PluginTest" name="test_by_default_doesnt_include_the_repoter" time="0.000007" file="./test/junit_plugin_test.rb" line="25" assertions="1"/>
  <testcase classname="PluginTest" name="test_by_default_the_plugin_is_disabled" time="0.000080" file="./test/junit_plugin_test.rb" line="6" assertions="1"/>
  <testcase classname="PluginTest" name="test_output_is_dumped_to_specified_filename" time="0.000043" file="./test/junit_plugin_test.rb" line="54" assertions="0"/>
  <testcase classname="PluginTest" name="test_output_is_dumped_to_reportxml_by_default" time="0.000029" file="./test/junit_plugin_test.rb" line="43" assertions="0"/>
  <testcase classname="ReporterTest" name="test_no_tests_generates_an_empty_suite" time="0.000074" file="./test/reporter_test.rb" line="11" assertions="2"/>
  <testcase classname="ReporterTest" name="test_xml_nodes_has_file_and_line_attributes" time="0.000403" file="./test/reporter_test.rb" line="44" assertions="4"/>
  <testcase classname="ReporterTest" name="test_formats_each_successful_result_with_a_formatter" time="0.000948" file="./test/reporter_test.rb" line="22" assertions="60"/>
  <testcase classname="ReporterTest" name="test_formats_each_failed_result_with_a_formatter" time="0.014718" file="./test/reporter_test.rb" line="32" assertions="1"/>
</testsuite>

```

</details>
