### PR TITLE
Enforce XML document encoding to UTF-8

### DIFF
--- a/lib/minitest/junit.rb
+++ b/lib/minitest/junit.rb
@@ -28,7 +28,7 @@ module Minitest
       end
 
       def report
-        doc = Ox::Document.new(:version => '1.0')
+        doc = Ox::Document.new(version: '1.0', encoding: 'UTF-8')
         instruct = Ox::Instruct.new(:xml)
         instruct[:version] = '1.0'
         instruct[:encoding] = 'UTF-8'
@@ -87,10 +87,6 @@ module Minitest
 
       def working_directory
         @working_directory ||= Dir.getwd
-      end
-
-      def failure_message(result)
-        "#{result.klass}##{result.name}: #{result.failure}"
       end
 
       def relative_to_cwd(path)

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -19,6 +19,18 @@ class ReporterTest < Minitest::Test
     )
   end
 
+  # NOTE: This test will generate a temp file: "test/tmp/report.xml"
+  def test_encoding
+    # Enforce File.external_encoding to UTF-8 to ensure that ASCII character will be correctly converted to UTF-8
+    file = File.new('test/tmp/report.xml', 'w:UTF-8')
+    reporter = Minitest::Junit::Reporter.new file, { hostname: '‹foo›' }
+    reporter.start
+    reporter.report
+    file.close
+
+    assert_match(/hostname="‹foo›"/, File.new('test/tmp/report.xml', 'r:UTF-8').read)
+  end
+
   def test_formats_each_successful_result_with_a_formatter
     reporter = create_reporter
 


### PR DESCRIPTION
See #11 

The only way I found to reproduce this issue in test is when writing NON ASCII characters into a file. All existing tests use all `StringIO` which does not allow reproduction...

Please review it, thanks @davidwessman  