### PR TITLE
Adds a wrapping <testsuites> to adhere to standard

### DIFF
--- a/lib/minitest/junit.rb
+++ b/lib/minitest/junit.rb
@@ -33,6 +33,7 @@ module Minitest
         instruct[:version] = '1.0'
         instruct[:encoding] = 'UTF-8'
         doc << instruct
+
         testsuite = Ox::Element.new('testsuite')
         testsuite['name'] = @options[:name] || 'minitest'
         testsuite['timestamp'] = @options[:timestamp]
@@ -46,7 +47,10 @@ module Minitest
           testsuite << format(result)
         end
 
-        doc << testsuite
+        testsuites = Ox::Element.new('testsuites')
+        testsuites << testsuite
+
+        doc << testsuites
         @io << Ox.dump(doc)
       end
 

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -14,7 +14,7 @@ class ReporterTest < Minitest::Test
     reporter.report
 
     assert_match(
-      %r{<?xml version="1.0" encoding="UTF-8"\?>\n<testsuite name="minitest" timestamp="[^"]+" hostname="[^"]+" tests="0" skipped="0" failures="0" errors="0" time="0.000000"\/>},
+      %r{<?xml version="1.0" encoding="UTF-8"\?>\n<testsuites>\n  <testsuite name="minitest" timestamp="[^"]+" hostname="[^"]+" tests="0" skipped="0" failures="0" errors="0" time="0.000000"\/>\n<\/testsuites>\n},
       reporter.output
     )
   end


### PR DESCRIPTION
- Based on
  https://docs.gitlab.com/ee/ci/testing/unit_test_reports.html#how-it-works
  https://www.ibm.com/docs/en/developer-for-zos/16.0?topic=formats-junit-xml-format
- Fixes #6