### PR TITLE
Adds support for Rails failure screenshots

### DIFF
--- a/lib/minitest/junit.rb
+++ b/lib/minitest/junit.rb
@@ -59,12 +59,6 @@ module Minitest
         testcase['line'] = result.source_location.last
         testcase['assertions'] = result.assertions
 
-        # Minitest 5.19 supports metadata
-        # Rails 7.1 adds `failure_screenshot_path` to metadata
-        if result.respond_to?('metadata') && result.metadata[:failure_screenshot_path]
-          testcase['screenshot'] = relative_to_cwd(result.metadata[:failure_screenshot_path])
-        end
-
         if result.skipped?
           skipped = Ox::Element.new('skipped')
           skipped['message'] = result
@@ -77,6 +71,16 @@ module Minitest
             failure_tag << format_backtrace(failure)
             testcase << failure_tag
           end
+        end
+
+        # Minitest 5.19 supports metadata
+        # Rails 7.1 adds `failure_screenshot_path` to metadata
+        # Output according to Gitlab format
+        # https://docs.gitlab.com/ee/ci/testing/unit_test_reports.html#view-junit-screenshots-on-gitlab
+        if result.respond_to?("metadata") && result.metadata[:failure_screenshot_path]
+          screenshot = Ox::Element.new("system-out")
+          screenshot << "[[ATTACHMENT|#{result.metadata[:failure_screenshot_path]}]]"
+          testcase << screenshot
         end
 
         testcase

--- a/lib/minitest/junit.rb
+++ b/lib/minitest/junit.rb
@@ -58,6 +58,13 @@ module Minitest
         testcase['file'] = relative_to_cwd(result.source_location.first)
         testcase['line'] = result.source_location.last
         testcase['assertions'] = result.assertions
+
+        # Minitest 5.19 supports metadata
+        # Rails 7.1 adds `failure_screenshot_path` to metadata
+        if result.respond_to?('metadata') && result.metadata[:failure_screenshot_path]
+          testcase['screenshot'] = relative_to_cwd(result.metadata[:failure_screenshot_path])
+        end
+
         if result.skipped?
           skipped = Ox::Element.new('skipped')
           skipped['message'] = result

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -37,8 +37,9 @@ class ReporterTest < Minitest::Test
     results.each do |result|
       parsed_report.xpath("//testcase[@name='#{result.name}']").any?
     end
-    # Check if some testcase has a failure
+    # Check if some testcase has a failure and screenshot path
     assert parsed_report.xpath("//testcase//failure").any?
+    assert parsed_report.xpath("//testcase[@screenshot]").any?
   end
 
   def test_xml_nodes_has_file_and_line_attributes
@@ -81,6 +82,11 @@ class ReporterTest < Minitest::Test
         end
       end.new
     end
+
+    if failures.positive?
+      test.metadata[:failure_screenshot_path] = '/tmp/screenshot.png'
+    end
+
     Minitest::Result.from test
   end
 

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -39,7 +39,7 @@ class ReporterTest < Minitest::Test
     end
     # Check if some testcase has a failure and screenshot path
     assert parsed_report.xpath("//testcase//failure").any?
-    assert parsed_report.xpath("//testcase[@screenshot]").any?
+    assert parsed_report.xpath("//testcase//system-out").any?
   end
 
   def test_xml_nodes_has_file_and_line_attributes


### PR DESCRIPTION
- Adds `screenshot` attribute to `<testcase>` with a path to a screenshot taken during a Rails test error.
- The `metadata` field was added in Minitest 5.19 and in Rails 7.1 the metadata field is populated in Rails.
- This has been the main purpose of my own gem, https://github.com/davidwessman/blinka_reporter, would be great to be able to rely on this gem instead!
