### PR TITLE
Make Ox optional, fallback to Nokogiri, stdlib

### DIFF
--- a/lib/minitest/junit.rb
+++ b/lib/minitest/junit.rb
@@ -1,12 +1,33 @@
 require 'minitest/junit/version'
 require 'minitest'
-require 'ox'
 require 'socket'
 require 'time'
+
+# XML backend: Ox (fastest) > Nokogiri (fast) > REXML (stdlib fallback).
+begin
+  require 'ox'
+  require 'minitest/junit/xml_ox'
+rescue LoadError
+  begin
+    require 'nokogiri'
+    require 'minitest/junit/xml_nokogiri'
+  rescue LoadError
+    require 'rexml/document'
+    require 'minitest/junit/xml_rexml'
+  end
+end
 
 # :nodoc:
 module Minitest
   module Junit
+    Document = if defined?(Ox)
+                 OxDocument
+               elsif defined?(Nokogiri)
+                 NokogiriDocument
+               else
+                 RexmlDocument
+               end
+
     # :nodoc:
     class Reporter
       def initialize(io, options)
@@ -15,6 +36,7 @@ module Minitest
         @options = options
         @options[:timestamp] = options.fetch(:timestamp, Time.now.iso8601)
         @options[:hostname] = options.fetch(:hostname, Socket.gethostname)
+        @doc = (options.delete(:document_class) || Document).new
       end
 
       def passed?
@@ -28,52 +50,47 @@ module Minitest
       end
 
       def report
-        doc = Ox::Document.new(version: '1.0', encoding: 'UTF-8')
-        instruct = Ox::Instruct.new(:xml)
-        instruct[:version] = '1.0'
-        instruct[:encoding] = 'UTF-8'
-        doc << instruct
+        doc = @doc.document
 
-        testsuite = Ox::Element.new('testsuite')
-        testsuite['name'] = @options[:name] || 'minitest'
-        testsuite['timestamp'] = @options[:timestamp]
-        testsuite['hostname'] = @options[:hostname]
-        testsuite['tests'] = @results.size
-        testsuite['skipped'] = @results.count(&:skipped?)
-        testsuite['failures'] = @results.count { |result| !result.error? && result.failure }
-        testsuite['errors'] = @results.count(&:error?)
-        testsuite['time'] = format_time(@results.map(&:time).inject(0, :+))
+        testsuites = @doc.element('testsuites')
+        testsuite = @doc.element('testsuite')
+        @doc.set_attr(testsuite, 'name', @options[:name] || 'minitest')
+        @doc.set_attr(testsuite, 'timestamp', @options[:timestamp])
+        @doc.set_attr(testsuite, 'hostname', @options[:hostname])
+        @doc.set_attr(testsuite, 'tests', @results.size)
+        @doc.set_attr(testsuite, 'skipped', @results.count(&:skipped?))
+        @doc.set_attr(testsuite, 'failures', @results.count { |result| !result.error? && result.failure })
+        @doc.set_attr(testsuite, 'errors', @results.count(&:error?))
+        @doc.set_attr(testsuite, 'time', format_time(@results.map(&:time).inject(0, :+)))
         @results.each do |result|
-          testsuite << format(result)
+          @doc.add_child(testsuite, format(result))
         end
 
-        testsuites = Ox::Element.new('testsuites')
-        testsuites << testsuite
-
-        doc << testsuites
-        @io << Ox.dump(doc)
+        @doc.add_child(testsuites, testsuite)
+        @doc.add_child(doc, testsuites)
+        @io << @doc.dump(doc)
       end
 
       def format(result, parent = nil)
-        testcase = Ox::Element.new('testcase')
-        testcase['classname'] = format_class(result)
-        testcase['name'] = format_name(result)
-        testcase['time'] = format_time(result.time)
-        testcase['file'] = relative_to_cwd(result.source_location.first)
-        testcase['line'] = result.source_location.last
-        testcase['assertions'] = result.assertions
+        testcase = @doc.element('testcase')
+        @doc.set_attr(testcase, 'classname', format_class(result))
+        @doc.set_attr(testcase, 'name', format_name(result))
+        @doc.set_attr(testcase, 'time', format_time(result.time))
+        @doc.set_attr(testcase, 'file', relative_to_cwd(result.source_location.first))
+        @doc.set_attr(testcase, 'line', result.source_location.last)
+        @doc.set_attr(testcase, 'assertions', result.assertions)
 
         if result.skipped?
-          skipped = Ox::Element.new('skipped')
-          skipped['message'] = result
-          skipped << ""
-          testcase << skipped
+          skipped = @doc.element('skipped')
+          @doc.set_attr(skipped, 'message', result)
+          @doc.add_text(skipped, '')
+          @doc.add_child(testcase, skipped)
         else
           result.failures.each do |failure|
-            failure_tag = Ox::Element.new(classify(failure))
-            failure_tag['message'] = result
-            failure_tag << format_backtrace(failure)
-            testcase << failure_tag
+            failure_tag = @doc.element(classify(failure))
+            @doc.set_attr(failure_tag, 'message', result)
+            @doc.add_text(failure_tag, format_backtrace(failure))
+            @doc.add_child(testcase, failure_tag)
           end
         end
 
@@ -82,9 +99,9 @@ module Minitest
         # Output according to Gitlab format
         # https://docs.gitlab.com/ee/ci/testing/unit_test_reports.html#view-junit-screenshots-on-gitlab
         if result.respond_to?("metadata") && result.metadata[:failure_screenshot_path]
-          screenshot = Ox::Element.new("system-out")
-          screenshot << "[[ATTACHMENT|#{result.metadata[:failure_screenshot_path]}]]"
-          testcase << screenshot
+          screenshot = @doc.element("system-out")
+          @doc.add_text(screenshot, "[[ATTACHMENT|#{result.metadata[:failure_screenshot_path]}]]")
+          @doc.add_child(testcase, screenshot)
         end
 
         testcase

--- a/lib/minitest/junit/xml_nokogiri.rb
+++ b/lib/minitest/junit/xml_nokogiri.rb
@@ -1,0 +1,31 @@
+module Minitest
+  module Junit
+    class NokogiriDocument
+      def document
+        @doc = Nokogiri::XML::Document.new
+        @doc.encoding = 'UTF-8'
+        @doc
+      end
+
+      def element(name)
+        Nokogiri::XML::Node.new(name, @doc)
+      end
+
+      def set_attr(el, name, value)
+        el[name.to_s] = value.to_s
+      end
+
+      def add_child(parent, child)
+        parent << child
+      end
+
+      def add_text(el, text)
+        el.content = text.to_s
+      end
+
+      def dump(doc)
+        doc.to_xml(indent: 2)
+      end
+    end
+  end
+end

--- a/lib/minitest/junit/xml_ox.rb
+++ b/lib/minitest/junit/xml_ox.rb
@@ -1,0 +1,34 @@
+module Minitest
+  module Junit
+    class OxDocument
+      def document
+        doc = Ox::Document.new(version: '1.0', encoding: 'UTF-8')
+        instruct = Ox::Instruct.new(:xml)
+        instruct[:version] = '1.0'
+        instruct[:encoding] = 'UTF-8'
+        doc << instruct
+        doc
+      end
+
+      def element(name)
+        Ox::Element.new(name)
+      end
+
+      def set_attr(el, name, value)
+        el[name] = value
+      end
+
+      def add_child(parent, child)
+        parent << child
+      end
+
+      def add_text(el, text)
+        el << text.to_s
+      end
+
+      def dump(doc)
+        Ox.dump(doc)
+      end
+    end
+  end
+end

--- a/lib/minitest/junit/xml_rexml.rb
+++ b/lib/minitest/junit/xml_rexml.rb
@@ -1,0 +1,35 @@
+module Minitest
+  module Junit
+    class RexmlDocument
+      def document
+        doc = REXML::Document.new
+        doc << REXML::XMLDecl.new('1.0', 'UTF-8')
+        doc
+      end
+
+      def element(name)
+        REXML::Element.new(name)
+      end
+
+      def set_attr(el, name, value)
+        el.add_attribute(name, value.to_s)
+      end
+
+      def add_child(parent, child)
+        parent << child
+      end
+
+      def add_text(el, text)
+        el.add_text(text.to_s)
+      end
+
+      def dump(doc)
+        output = String.new
+        formatter = REXML::Formatters::Pretty.new(2)
+        formatter.compact = true
+        formatter.write(doc, output)
+        output << "\n"
+      end
+    end
+  end
+end

--- a/minitest-junit.gemspec
+++ b/minitest-junit.gemspec
@@ -19,11 +19,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'minitest', '~> 5.11'
-  spec.add_dependency 'ox', '~> 2', '>= 2.14.2'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'nokogiri'
+  spec.add_development_dependency 'ox', '~> 2'
   spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'rexml'
   spec.add_development_dependency 'rake', '~> 13'
   spec.add_development_dependency 'rubocop', '~> 1'
 end

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -3,32 +3,42 @@ require 'stringio'
 require 'time'
 require 'nokogiri'
 
+require 'ox'
+require 'rexml/document'
 require 'minitest/junit'
+require 'minitest/junit/xml_ox'
+require 'minitest/junit/xml_nokogiri'
+require 'minitest/junit/xml_rexml'
 
 class FakeTestName; end
 
-class ReporterTest < Minitest::Test
+module ReporterTests
   def test_no_tests_generates_an_empty_suite
     reporter = create_reporter
-
     reporter.report
 
-    assert_match(
-      %r{<?xml version="1.0" encoding="UTF-8"\?>\n<testsuites>\n  <testsuite name="minitest" timestamp="[^"]+" hostname="[^"]+" tests="0" skipped="0" failures="0" errors="0" time="0.000000"\/>\n<\/testsuites>\n},
-      reporter.output
-    )
+    parsed = Nokogiri::XML(reporter.output)
+    testsuite = parsed.at_xpath('//testsuite')
+    assert_equal 'minitest', testsuite['name']
+    assert testsuite['timestamp']
+    assert testsuite['hostname']
+    assert_equal '0', testsuite['tests']
+    assert_equal '0', testsuite['skipped']
+    assert_equal '0', testsuite['failures']
+    assert_equal '0', testsuite['errors']
+    assert_equal '0.000000', testsuite['time']
   end
 
   # NOTE: This test will generate a temp file: "test/tmp/report.xml"
   def test_encoding
-    # Enforce File.external_encoding to UTF-8 to ensure that ASCII character will be correctly converted to UTF-8
     file = File.new('test/tmp/report.xml', 'w:UTF-8')
-    reporter = Minitest::Junit::Reporter.new file, { hostname: '‹foo›' }
+    reporter = Minitest::Junit::Reporter.new file, { hostname: '‹foo›', document_class: document_class }
     reporter.start
     reporter.report
     file.close
 
-    assert_match(/hostname="‹foo›"/, File.new('test/tmp/report.xml', 'r:UTF-8').read)
+    parsed = Nokogiri::XML(File.read('test/tmp/report.xml'))
+    assert_equal '‹foo›', parsed.at_xpath('//testsuite')['hostname']
   end
 
   def test_formats_each_successful_result_with_a_formatter
@@ -36,8 +46,11 @@ class ReporterTest < Minitest::Test
 
     results = do_formatting_test(reporter, count: rand(100), cause_failures: 0)
 
+    parsed = Nokogiri::XML(reporter.output)
     results.each do |result|
-      assert_match("<testcase classname=\"FakeTestName\" name=\"#{result.name}\"", reporter.output)
+      node = parsed.at_xpath("//testcase[@name='#{result.name}']")
+      assert node, "Expected testcase with name #{result.name}"
+      assert_equal 'FakeTestName', node['classname']
     end
   end
 
@@ -45,27 +58,30 @@ class ReporterTest < Minitest::Test
     reporter = create_reporter
 
     results = do_formatting_test(reporter, count: rand(100), cause_failures: 1)
-    parsed_report = Nokogiri::XML(reporter.output)
+    parsed = Nokogiri::XML(reporter.output)
     results.each do |result|
-      parsed_report.xpath("//testcase[@name='#{result.name}']").any?
+      assert parsed.at_xpath("//testcase[@name='#{result.name}']")
     end
-    # Check if some testcase has a failure and screenshot path
-    assert parsed_report.xpath("//testcase//failure").any?
-    assert parsed_report.xpath("//testcase//system-out").any?
+    assert parsed.xpath("//testcase//failure").any?
+    assert parsed.xpath("//testcase//system-out").any?
   end
 
   def test_xml_nodes_has_file_and_line_attributes
     reporter = create_reporter
     results = do_formatting_test(reporter, count: 2, cause_failures: 1)
-    parsed_report = Nokogiri::XML(reporter.output)
-    example_node = parsed_report.xpath("//testcase").first
+    parsed = Nokogiri::XML(reporter.output)
+    example_node = parsed.xpath("//testcase").first
     assert example_node.has_attribute?('file')
     assert example_node.has_attribute?('line')
-    assert_equal 'unknown', example_node.attribute('file').value
-    assert_equal '-1', example_node.attribute('line').value
+    assert_equal 'unknown', example_node['file']
+    assert_equal '-1', example_node['line']
   end
 
   private
+
+  def document_class
+    self.class::DOCUMENT_CLASS
+  end
 
   def do_formatting_test(reporter, count: 1, cause_failures: 0)
     results = count.times.map do |i|
@@ -103,12 +119,27 @@ class ReporterTest < Minitest::Test
   end
 
   def create_reporter(options = {})
-    io = StringIO.new ''
-    reporter = Minitest::Junit::Reporter.new io, options
+    io = StringIO.new
+    reporter = Minitest::Junit::Reporter.new io, options.merge(document_class: document_class)
     def reporter.output
       @io.string
     end
     reporter.start
     reporter
   end
+end
+
+class ReporterTestOx < Minitest::Test
+  DOCUMENT_CLASS = Minitest::Junit::OxDocument
+  include ReporterTests
+end
+
+class ReporterTestNokogiri < Minitest::Test
+  DOCUMENT_CLASS = Minitest::Junit::NokogiriDocument
+  include ReporterTests
+end
+
+class ReporterTestRexml < Minitest::Test
+  DOCUMENT_CLASS = Minitest::Junit::RexmlDocument
+  include ReporterTests
 end

--- a/test/testcase_formatter_test.rb
+++ b/test/testcase_formatter_test.rb
@@ -1,8 +1,14 @@
 require 'minitest/autorun'
 require 'stringio'
 require 'time'
+require 'nokogiri'
 
+require 'ox'
+require 'rexml/document'
 require 'minitest/junit'
+require 'minitest/junit/xml_ox'
+require 'minitest/junit/xml_nokogiri'
+require 'minitest/junit/xml_rexml'
 
 class FakeTestName; end
 
@@ -12,15 +18,16 @@ module FirstModule
   end
 end
 
-class TestCaseFormatter < Minitest::Test
+module TestCaseFormatterTests
   def test_all_tests_generate_testcase_tag
     test = create_test_result
     reporter = create_reporter
+    reporter.record test
+    reporter.report
 
-    assert_match(
-      test.name,
-      reporter.format(test).attributes['name']
-    )
+    parsed = Nokogiri::XML(reporter.output)
+    node = parsed.at_xpath("//testcase")
+    assert_equal test.name, node['name']
   end
 
   def test_skipped_tests_generates_skipped_tag
@@ -28,10 +35,12 @@ class TestCaseFormatter < Minitest::Test
     test.failures << create_error(Minitest::Skip)
     reporter = create_reporter
     reporter.record test
-
     reporter.report
 
-    assert_match(/<skipped message="[^<>]+"\><\/skipped>\n\s+<\/testcase>\n\s*<\/testsuite>\n/, reporter.output)
+    parsed = Nokogiri::XML(reporter.output)
+    skipped = parsed.at_xpath("//testcase/skipped")
+    assert skipped, "Expected skipped tag"
+    assert skipped['message']
   end
 
   def test_failing_tests_creates_failure_tag
@@ -39,10 +48,10 @@ class TestCaseFormatter < Minitest::Test
     test.failures << create_error(Minitest::Assertion)
     reporter = create_reporter
     reporter.record test
-
     reporter.report
 
-    assert_match(/<failure/, reporter.output)
+    parsed = Nokogiri::XML(reporter.output)
+    assert parsed.at_xpath("//testcase/failure")
   end
 
   def test_other_errors_generates_error_tag
@@ -50,23 +59,28 @@ class TestCaseFormatter < Minitest::Test
     test.failures << Minitest::UnexpectedError.new(create_error(Exception))
     reporter = create_reporter
     reporter.record test
-
     reporter.report
 
-    assert_match(/<error/, reporter.output)
+    parsed = Nokogiri::XML(reporter.output)
+    assert parsed.at_xpath("//testcase/error")
   end
 
   def test_jenkins_sanitizer_uses_modules_as_packages
     test = create_test_result FirstModule::SecondModule::TestClass
     reporter = create_reporter junit_jenkins: true
     reporter.record test
-
     reporter.report
 
-    assert_match 'FirstModule::SecondModule.TestClass', reporter.output
+    parsed = Nokogiri::XML(reporter.output)
+    node = parsed.at_xpath("//testcase")
+    assert_equal 'FirstModule::SecondModule.TestClass', node['classname']
   end
 
   private
+
+  def document_class
+    self.class::DOCUMENT_CLASS
+  end
 
   def create_error(klass)
     fail klass, "A #{klass} failure"
@@ -90,12 +104,27 @@ class TestCaseFormatter < Minitest::Test
   end
 
   def create_reporter(options = {})
-    io = StringIO.new ''
-    reporter = Minitest::Junit::Reporter.new io, options
+    io = StringIO.new
+    reporter = Minitest::Junit::Reporter.new io, options.merge(document_class: document_class)
     def reporter.output
       @io.string
     end
     reporter.start
     reporter
   end
+end
+
+class TestCaseFormatterOx < Minitest::Test
+  DOCUMENT_CLASS = Minitest::Junit::OxDocument
+  include TestCaseFormatterTests
+end
+
+class TestCaseFormatterNokogiri < Minitest::Test
+  DOCUMENT_CLASS = Minitest::Junit::NokogiriDocument
+  include TestCaseFormatterTests
+end
+
+class TestCaseFormatterRexml < Minitest::Test
+  DOCUMENT_CLASS = Minitest::Junit::RexmlDocument
+  include TestCaseFormatterTests
 end


### PR DESCRIPTION
In my local benchmarking, Ox over Nokogiri saves about 1ms per 500 tests, and 3.5ms per 500 tests over rexml on ruby 3.4, and on ruby 4, the difference between all three is completely negligible - rexml was actually slightly faster.
  
  | Backend      | Ruby 3.4         | Ruby 4.0         | Speedup    |
  |--------------|------------------|------------------|------------|
  | **Ox**       | 525 i/s (1.9ms)  | 712 i/s (1.4ms)  | 1.4x       |
  | **Nokogiri** | 346 i/s (2.9ms)  | 713 i/s (1.4ms)  | 2.1x       |
  | **REXML**    | 182 i/s (5.5ms)  | 724 i/s (1.4ms)  | **4.0x**   |

The performance benefit isn't worth the carrying cost of another dependency for us at least, even on ruby 3.4.

So, this PR uses an adapter pattern to use Ox if it's installed, Nokogiri if it's installed, and rexml otherwise. This way users can opt into ox or nokogiri for improved performance on ruby 3.4 if it's worth it to them and otherwise dependencies are kept to a minimum.