### PR TITLE
Group results by filename

### DIFF
--- a/lib/minitest/junit.rb
+++ b/lib/minitest/junit.rb
@@ -34,21 +34,30 @@ module Minitest
         instruct[:encoding] = 'UTF-8'
         doc << instruct
 
-        testsuite = Ox::Element.new('testsuite')
-        testsuite['name'] = @options[:name] || 'minitest'
-        testsuite['timestamp'] = @options[:timestamp]
-        testsuite['hostname'] = @options[:hostname]
-        testsuite['tests'] = @results.size
-        testsuite['skipped'] = @results.count(&:skipped?)
-        testsuite['failures'] = @results.count { |result| !result.error? && result.failure }
-        testsuite['errors'] = @results.count(&:error?)
-        testsuite['time'] = format_time(@results.map(&:time).inject(0, :+))
-        @results.each do |result|
-          testsuite << format(result)
-        end
-
         testsuites = Ox::Element.new('testsuites')
-        testsuites << testsuite
+        testsuites['name'] = @options[:name] || 'minitest'
+        testsuites['tests'] = @results.size
+        testsuites['skipped'] = @results.count(&:skipped?)
+        testsuites['failures'] = @results.count { |result| !result.error? && result.failure }
+        testsuites['errors'] = @results.count(&:error?)
+        testsuites['time'] = format_time(@results.map(&:time).inject(0, :+))
+
+        grouped = @results.group_by { |result| format_file(result) }
+        grouped.each do |file, results|
+          testsuite = Ox::Element.new('testsuite')
+          testsuite['name'] = file
+          testsuite['timestamp'] = @options[:timestamp]
+          testsuite['hostname'] = @options[:hostname]
+          testsuite['tests'] = results.size
+          testsuite['skipped'] = results.count(&:skipped?)
+          testsuite['failures'] = results.count { |result| !result.error? && result.failure }
+          testsuite['errors'] = results.count(&:error?)
+          testsuite['time'] = format_time(results.map(&:time).inject(0, :+))
+          results.each do |result|
+            testsuite << format(result)
+          end
+          testsuites << testsuite
+        end
 
         doc << testsuites
         @io << Ox.dump(doc)
@@ -114,11 +123,16 @@ module Minitest
         end.join("\n")
       end
 
+      def format_file(result)
+        relative_to_cwd(result.source_location.first).sub(%r{\A\./}, "")
+      end
+
       def format_class(result)
         if @options[:junit_jenkins]
           result.klass.to_s.gsub(/(.*)::(.*)/, '\1.\2')
         else
-          result.klass
+          fp = relative_to_cwd(result.source_location.first)
+          fp.sub(%r{\.[^/]*\Z}, "").gsub("/", ".").gsub(%r{\A\.+|\.+\Z}, "")
         end
       end
 

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -14,7 +14,7 @@ class ReporterTest < Minitest::Test
     reporter.report
 
     assert_match(
-      %r{<?xml version="1.0" encoding="UTF-8"\?>\n<testsuites>\n  <testsuite name="minitest" timestamp="[^"]+" hostname="[^"]+" tests="0" skipped="0" failures="0" errors="0" time="0.000000"\/>\n<\/testsuites>\n},
+      %r{<?xml version="1.0" encoding="UTF-8"\?>\n<testsuites name="minitest" tests="0" skipped="0" failures="0" errors="0" time="0.000000"\/>\n},
       reporter.output
     )
   end
@@ -25,6 +25,7 @@ class ReporterTest < Minitest::Test
     file = File.new('test/tmp/report.xml', 'w:UTF-8')
     reporter = Minitest::Junit::Reporter.new file, { hostname: '‹foo›' }
     reporter.start
+    reporter.record create_test_result
     reporter.report
     file.close
 
@@ -37,7 +38,7 @@ class ReporterTest < Minitest::Test
     results = do_formatting_test(reporter, count: rand(100), cause_failures: 0)
 
     results.each do |result|
-      assert_match("<testcase classname=\"FakeTestName\" name=\"#{result.name}\"", reporter.output)
+      assert_match("<testcase classname=\"test.fake_test\" name=\"#{result.name}\"", reporter.output)
     end
   end
 
@@ -61,8 +62,8 @@ class ReporterTest < Minitest::Test
     example_node = parsed_report.xpath("//testcase").first
     assert example_node.has_attribute?('file')
     assert example_node.has_attribute?('line')
-    assert_equal 'unknown', example_node.attribute('file').value
-    assert_equal '-1', example_node.attribute('line').value
+    assert_equal './test/fake_test.rb', example_node.attribute('file').value
+    assert_equal '1', example_node.attribute('line').value
   end
 
   private
@@ -79,7 +80,7 @@ class ReporterTest < Minitest::Test
     results
   end
 
-  def create_test_result(name: FakeTestName, methodname: 'test_method_name', successes: 1, failures: 0)
+  def create_test_result(name: FakeTestName, methodname: 'test_method_name', successes: 1, failures: 0, source_location: ['./test/fake_test.rb', 1])
     test = Class.new Minitest::Test do
       define_method 'class' do
         name
@@ -99,7 +100,9 @@ class ReporterTest < Minitest::Test
       test.metadata[:failure_screenshot_path] = '/tmp/screenshot.png'
     end
 
-    Minitest::Result.from test
+    result = Minitest::Result.from test
+    result.source_location = source_location
+    result
   end
 
   def create_reporter(options = {})

--- a/test/testcase_formatter_test.rb
+++ b/test/testcase_formatter_test.rb
@@ -74,7 +74,7 @@ class TestCaseFormatter < Minitest::Test
     e
   end
 
-  def create_test_result(name = FakeTestName)
+  def create_test_result(name = FakeTestName, source_location: ['./test/fake_test.rb', 1])
     test = Class.new Minitest::Test do
       define_method 'class' do
         name
@@ -82,7 +82,9 @@ class TestCaseFormatter < Minitest::Test
     end.new 'test_method_name'
     test.time = a_number
     test.assertions = a_number
-    Minitest::Result.from test
+    result = Minitest::Result.from test
+    result.source_location = source_location
+    result
   end
 
   def a_number


### PR DESCRIPTION
I don't know if this is a good candidate for merging because others also have this issue or a quirk of our CI provider (Semaphore CI), but the output of this is significantly worse than `rspec_junit_formatter` for us as it does not group test results by file.

This PR does that, here's a before/after:

<img width="1710" height="837" alt="CleanShot 2026-02-16 at 15 47 56" src="https://github.com/user-attachments/assets/cce2009a-b9ba-495e-9ab1-3dcde0357a8c" />

<img width="1710" height="837" alt="CleanShot 2026-02-16 at 15 49 07" src="https://github.com/user-attachments/assets/b7438fef-4eab-4846-97e3-3b2c01c5ca1b" />